### PR TITLE
Added an option to select the monitor to draw the command line on.

### DIFF
--- a/res/default_config/.vindrc
+++ b/res/default_config/.vindrc
@@ -85,7 +85,17 @@ set cmd_fontcolor=c8c8c8
 set cmd_bgcolor=323232
 
 " Position
-set cmd_roughpos=LowerMid
+"    UpperLeft | UpperMid | UpperRight
+"     MidLeft  |  Center  |  MidRight
+"    LowerLeft | LowerMid | LowerRight
+set cmd_roughpos=LowerLeft
+
+" Monitor to draw the virtual command line on.
+"   primary  : Primary monitor.
+"   all      : All monitor.
+"   active   : Monitor where the selected window is located.
+"   {number} : {number}th monitor. For example, `set cmd_monitor=1`.
+set cmd_monitor=active
 
 " Horizontal Margin
 set cmd_xmargin=32

--- a/src/bind/mouse/jump_cursor.cpp
+++ b/src/bind/mouse/jump_cursor.cpp
@@ -36,7 +36,7 @@ namespace vind
         void JumpToRight::sprocess() {
             auto pos = util::get_cursor_pos() ;
 
-            auto box = util::get_conbined_metrics() ;
+            auto box = util::get_combined_metrics() ;
 
             auto& settable = core::SetTable::get_instance() ;
             util::set_cursor_pos(
@@ -59,7 +59,7 @@ namespace vind
         {}
         void JumpToTop::sprocess() {
             auto pos = util::get_cursor_pos() ;
-            auto box = util::get_conbined_metrics() ;
+            auto box = util::get_combined_metrics() ;
 
             util::set_cursor_pos(pos.x(), box.top()) ;
         }
@@ -79,7 +79,7 @@ namespace vind
         {}
         void JumpToBottom::sprocess() {
             auto pos = util::get_cursor_pos() ;
-            auto box = util::get_conbined_metrics() ;
+            auto box = util::get_combined_metrics() ;
 
             auto& settable = core::SetTable::get_instance() ;
             util::set_cursor_pos(
@@ -102,7 +102,7 @@ namespace vind
         {}
         void JumpToHorizontalCenter::sprocess() {
             auto pos = util::get_cursor_pos() ;
-            auto box = util::get_conbined_metrics() ;
+            auto box = util::get_combined_metrics() ;
             util::set_cursor_pos(box.center_x(), pos.y()) ;
         }
         void JumpToHorizontalCenter::sprocess(core::NTypeLogger& parent_lgr) {
@@ -121,7 +121,7 @@ namespace vind
         {}
         void JumpToVerticalCenter::sprocess() {
             auto pos = util::get_cursor_pos() ;
-            auto box = util::get_conbined_metrics() ;
+            auto box = util::get_combined_metrics() ;
             util::set_cursor_pos(pos.x(), box.center_y()) ;
         }
         void JumpToVerticalCenter::sprocess(core::NTypeLogger& parent_lgr) {

--- a/src/bind/mouse/jump_keybrd.cpp
+++ b/src/bind/mouse/jump_keybrd.cpp
@@ -74,7 +74,7 @@ namespace vind
             //ignore toggle keys (for example, CapsLock, NumLock, IME....)
             auto toggle_keys = igate.pressed_list() ;
 
-            auto box = util::get_conbined_metrics() ;
+            auto box = util::get_combined_metrics() ;
 
             auto width  = box.width() ;
             auto height = box.height() ;

--- a/src/bind/window/winresizer.cpp
+++ b/src/bind/window/winresizer.cpp
@@ -107,7 +107,7 @@ namespace vind
                 auto hwnd = util::get_foreground_window() ;
                 auto rect = util::get_window_rect(hwnd) ;
 
-                auto cb_rect = util::get_conbined_metrics() ;
+                auto cb_rect = util::get_combined_metrics() ;
 
                 auto left = rect.left() ;
                 auto top = rect.top() ;

--- a/src/opt/autotrack_popup.cpp
+++ b/src/opt/autotrack_popup.cpp
@@ -54,19 +54,19 @@ namespace vind
         AutotrackPopup::AutotrackPopup(AutotrackPopup&&)            = default ;
         AutotrackPopup& AutotrackPopup::operator=(AutotrackPopup&&) = default ;
 
-        void AutotrackPopup::do_enable() const {
+        void AutotrackPopup::do_enable() {
             if(get_property() != TRUE) {
                 set_property(TRUE) ;
             }
         }
 
-        void AutotrackPopup::do_disable() const {
+        void AutotrackPopup::do_disable() {
             if(get_property() != FALSE) {
                 set_property(FALSE) ;
             }
         }
 
-        void AutotrackPopup::do_process() const {
+        void AutotrackPopup::do_process() {
         }
     }
 }

--- a/src/opt/autotrack_popup.hpp
+++ b/src/opt/autotrack_popup.hpp
@@ -12,9 +12,9 @@ namespace vind
             struct Impl ;
             std::unique_ptr<Impl> pimpl ;
 
-            void do_enable() const override ;
-            void do_disable() const override ;
-            void do_process() const override ;
+            void do_enable() override ;
+            void do_disable() override ;
+            void do_process() override ;
 
         public:
             explicit AutotrackPopup() ;

--- a/src/opt/blockstylecaret.cpp
+++ b/src/opt/blockstylecaret.cpp
@@ -168,10 +168,10 @@ namespace vind
         BlockStyleCaret::BlockStyleCaret(BlockStyleCaret&&)            = default ;
         BlockStyleCaret& BlockStyleCaret::operator=(BlockStyleCaret&&) = default ;
 
-        void BlockStyleCaret::do_enable() const {
+        void BlockStyleCaret::do_enable() {
         }
 
-        void BlockStyleCaret::do_disable() const {
+        void BlockStyleCaret::do_disable() {
             auto& settable = core::SetTable::get_instance() ;
             auto mode = util::A2a(
                     settable.get("blockstylecaret_mode").get<std::string>()) ;
@@ -222,7 +222,7 @@ namespace vind
             pimpl->is_enabled_ = true ;
         }
 
-        void BlockStyleCaret::do_process() const {
+        void BlockStyleCaret::do_process() {
             auto& settable = core::SetTable::get_instance() ;
             auto mode = util::A2a(
                     settable.get("blockstylecaret_mode").get<std::string>()) ;

--- a/src/opt/blockstylecaret.hpp
+++ b/src/opt/blockstylecaret.hpp
@@ -13,9 +13,9 @@ namespace vind
             struct Impl ;
             std::unique_ptr<Impl> pimpl ;
 
-            void do_enable() const override ;
-            void do_disable() const override ;
-            void do_process() const override ;
+            void do_enable() override ;
+            void do_disable() override ;
+            void do_process() override ;
 
         public:
             explicit BlockStyleCaret() ;

--- a/src/opt/dedicate_to_window.cpp
+++ b/src/opt/dedicate_to_window.cpp
@@ -24,10 +24,10 @@ namespace vind
         : OptionCreator("dedicate_to_window")
         {}
 
-        void Dedicate2Window::do_enable() const {
+        void Dedicate2Window::do_enable() {
         }
 
-        void Dedicate2Window::do_disable() const {
+        void Dedicate2Window::do_disable() {
         }
 
         void Dedicate2Window::enable_targeting() {
@@ -48,7 +48,7 @@ namespace vind
             }
         }
 
-        void Dedicate2Window::do_process() const {
+        void Dedicate2Window::do_process() {
             if(!target_hwnd_)  return ;
 
             auto foreground_hwnd = util::get_foreground_window() ;

--- a/src/opt/dedicate_to_window.hpp
+++ b/src/opt/dedicate_to_window.hpp
@@ -12,9 +12,9 @@ namespace vind
     {
         class Dedicate2Window : public OptionCreator<Dedicate2Window> {
         private:
-            void do_enable() const override ;
-            void do_disable() const override ;
-            void do_process() const override ;
+            void do_enable() override ;
+            void do_disable() override ;
+            void do_process() override ;
 
             static HWND target_hwnd_ ;
             static HWND past_hwnd_ ;

--- a/src/opt/option.cpp
+++ b/src/opt/option.cpp
@@ -29,13 +29,13 @@ namespace vind
               name_(std::move(name))
             {}
 
-            virtual ~Impl() noexcept         = default ;
+            virtual ~Impl() noexcept = default ;
 
-            Impl(Impl&&) noexcept            = default ;
+            Impl(Impl&&) noexcept = default ;
             Impl& operator=(Impl&&) noexcept = default ;
 
-            Impl(const Impl&)                = default ;
-            Impl& operator=(const Impl&)     = default ;
+            Impl(const Impl&) = default ;
+            Impl& operator=(const Impl&) = default ;
         } ;
 
         Option::Option(const std::string& name)
@@ -46,9 +46,9 @@ namespace vind
         : pimpl(std::make_unique<Impl>(std::move(name)))
         {}
 
-        Option::~Option() noexcept                     = default ;
-        Option::Option(Option&&) noexcept              = default ;
-        Option& Option::operator=(Option&&) noexcept   = default ;
+        Option::~Option() noexcept = default ;
+        Option::Option(Option&&) noexcept = default ;
+        Option& Option::operator=(Option&&) noexcept = default ;
 
         const std::string& Option::name() const noexcept {
             return pimpl->name_ ;
@@ -81,7 +81,7 @@ namespace vind
             return pimpl->flag_ ;
         }
 
-        void Option::process() const {
+        void Option::process() {
             if(!pimpl->flag_) {
                 return ;
             }

--- a/src/opt/option.hpp
+++ b/src/opt/option.hpp
@@ -15,9 +15,9 @@ namespace vind
         private:
             struct Impl ;
             std::unique_ptr<Impl> pimpl ;
-            virtual void do_enable() const  = 0 ;
-            virtual void do_disable() const = 0 ;
-            virtual void do_process() const = 0 ;
+            virtual void do_enable() = 0 ;
+            virtual void do_disable() = 0 ;
+            virtual void do_process() = 0 ;
 
         public:
             using SPtr = std::shared_ptr<Option> ;
@@ -39,7 +39,7 @@ namespace vind
             void disable() ;
 
             bool is_enabled() const noexcept ;
-            void process() const ;
+            void process() ;
         } ;
 
 

--- a/src/opt/suppress_for_vim.cpp
+++ b/src/opt/suppress_for_vim.cpp
@@ -21,13 +21,13 @@ namespace vind
         : OptionCreator("suppress_for_vim")
         {}
 
-        void SuppressForVim::do_enable() const {
+        void SuppressForVim::do_enable() {
         }
 
-        void SuppressForVim::do_disable() const {
+        void SuppressForVim::do_disable() {
         }
 
-        void SuppressForVim::do_process() const {
+        void SuppressForVim::do_process() {
             if(core::get_global_mode() == core::Mode::RESIDENT) {
                 return ;
             }

--- a/src/opt/suppress_for_vim.hpp
+++ b/src/opt/suppress_for_vim.hpp
@@ -9,9 +9,9 @@ namespace vind
     {
         class SuppressForVim : public OptionCreator<SuppressForVim> {
         private:
-            void do_enable() const override ;
-            void do_disable() const override ;
-            void do_process() const override ;
+            void do_enable() override ;
+            void do_disable() override ;
+            void do_process() override ;
 
         public:
             explicit SuppressForVim() ;

--- a/src/opt/uiacachebuild.cpp
+++ b/src/opt/uiacachebuild.cpp
@@ -21,14 +21,14 @@ namespace vind
         : OptionCreator("uiacachebuild")
         {}
 
-        void AsyncUIACacheBuilder::do_enable() const {
+        void AsyncUIACacheBuilder::do_enable() {
         }
 
-        void AsyncUIACacheBuilder::do_disable() const {
+        void AsyncUIACacheBuilder::do_disable() {
             caches_.clear() ;
         }
 
-        void AsyncUIACacheBuilder::do_process() const {
+        void AsyncUIACacheBuilder::do_process() {
             // Ignore in Insert Mode or Resident Mode.
             using core::Mode ;
             auto mode = core::get_global_mode() ;

--- a/src/opt/uiacachebuild.hpp
+++ b/src/opt/uiacachebuild.hpp
@@ -16,9 +16,9 @@ namespace vind
     {
         class AsyncUIACacheBuilder : public OptionCreator<AsyncUIACacheBuilder> {
         private:
-            void do_enable() const override ;
-            void do_disable() const override ;
-            void do_process() const override ;
+            void do_enable() override ;
+            void do_disable() override ;
+            void do_process() override ;
 
             static std::unordered_map<HWND, UICache> caches_ ;
 

--- a/src/opt/vcmdline.cpp
+++ b/src/opt/vcmdline.cpp
@@ -3,7 +3,6 @@
 #include <windows.h>
 
 #include <chrono>
-#include <functional>
 #include <memory>
 #include <sstream>
 #include <unordered_map>
@@ -256,19 +255,18 @@ namespace vind
 {
     namespace opt
     {
-        using Projection = std::function<util::Point2D(LONG, LONG)> ;
         struct VCmdLine::Impl {
             util::DisplayTextPainter dtp_{25, FW_MEDIUM, "Consolas"} ;
 
-            std::unique_ptr<Projector> projector_{nullptr} ;
-            int extra_ = 0 ;
-
-            ProjectionMethod proj_method_ = ProjectionMethod::PRIMARY ;
+            std::chrono::seconds fadeout_time_{} ;
 
             std::vector<util::Point2D> coords_{} ;
-            std::size_t fixed_monitor_idx_ = 0 ;
+            int extra_ = 0 ;
 
-            std::chrono::seconds fadeout_time_{} ;
+            std::unique_ptr<Projector> projector_{nullptr} ;
+
+            ProjectionMethod proj_method_ = ProjectionMethod::PRIMARY ;
+            std::size_t fixed_monitor_idx_ = 0 ;
 
             std::chrono::seconds coords_update_interval_{} ;
             std::chrono::system_clock::time_point last_coords_update_{} ;

--- a/src/opt/vcmdline.cpp
+++ b/src/opt/vcmdline.cpp
@@ -3,28 +3,275 @@
 #include <windows.h>
 
 #include <chrono>
+#include <functional>
 #include <memory>
+#include <sstream>
 #include <unordered_map>
+#include <vector>
 
 #include "core/errlogger.hpp"
 #include "core/mode.hpp"
 #include "core/path.hpp"
 #include "core/settable.hpp"
+#include "util/box2d.hpp"
+#include "util/debug.hpp"
+#include "util/def.hpp"
 #include "util/display_text_painter.hpp"
+#include "util/point2d.hpp"
 #include "util/screen_metrics.hpp"
+#include "util/string.hpp"
 #include "util/winwrap.hpp"
+
+
+namespace
+{
+    enum class ProjectionMethod {
+        PRIMARY,
+        ALL,
+        FIXED,
+        ACTIVE,
+    } ;
+
+    using namespace vind ;
+
+    struct Projector {
+        const int out_margin_x_ ;
+        const int out_margin_y_ ;
+        const int area_bias_x_ ;
+
+        template <typename T1>
+        Projector(T1 out_margin_x, T1 out_margin_y)
+        : out_margin_x_(static_cast<int>(out_margin_x)),
+          out_margin_y_(static_cast<int>(out_margin_y)),
+          area_bias_x_(-256)
+        {}
+
+        template <typename T1, typename T2>
+        Projector(T1 out_margin_x, T1 out_margin_y, T2 area_bias_x)
+        : out_margin_x_(static_cast<int>(out_margin_x)),
+          out_margin_y_(static_cast<int>(out_margin_y)),
+          area_bias_x_(static_cast<int>(area_bias_x))
+        {}
+
+        virtual ~Projector() noexcept = default ;
+
+        virtual std::tuple<int, int> project(int origin_x, int origin_y, int w, int h) = 0 ;
+    } ;
+
+    struct UpperLeftProjector : public Projector {
+        template <typename... Args>
+        UpperLeftProjector(Args&&... args)
+        : Projector(args...)
+        {}
+
+        std::tuple<int, int> project(
+                int origin_x,
+                int origin_y,
+                int UNUSED(w),
+                int UNUSED(h)) override {
+            return {
+                origin_x + out_margin_x_,
+                origin_y + out_margin_y_
+            } ;
+        }
+    } ;
+
+    struct UpperMidProjector : public Projector {
+        template <typename... Args>
+        UpperMidProjector(Args&&... args)
+        : Projector(args...)
+        {}
+
+        std::tuple<int, int> project(
+                int origin_x,
+                int origin_y,
+                int w,
+                int UNUSED(h)) override {
+            return {
+                origin_x + w / 2 + area_bias_x_,
+                origin_y + out_margin_y_
+            } ;
+        }
+    } ;
+
+    struct UpperRightProjector : public Projector {
+        template <typename... Args>
+        UpperRightProjector(Args&&... args)
+        : Projector(args...)
+        {}
+
+        std::tuple<int, int> project(
+                int origin_x,
+                int origin_y,
+                int w,
+                int UNUSED(h)) override {
+            return {
+                origin_x + w - out_margin_x_ + area_bias_x_,
+                origin_y + out_margin_y_
+            } ;
+        }
+    } ;
+
+    struct MidLeftProjector : public Projector {
+        template <typename... Args>
+        MidLeftProjector(Args&&... args)
+        : Projector(args...)
+        {}
+
+        std::tuple<int, int> project(
+                int origin_x,
+                int origin_y,
+                int UNUSED(w),
+                int h) override {
+            return {
+                origin_x + out_margin_x_,
+                origin_y + h / 2
+            } ;
+        }
+    } ;
+
+    struct CenterProjector : public Projector {
+        template <typename... Args>
+        CenterProjector(Args&&... args)
+        : Projector(args...)
+        {}
+
+        std::tuple<int, int> project(
+                int origin_x,
+                int origin_y,
+                int w,
+                int h) override {
+            return {
+                origin_x + w / 2 + area_bias_x_,
+                origin_y + h / 2
+            } ;
+        }
+    } ;
+
+    struct MidRightProjector : public Projector {
+        template <typename... Args>
+        MidRightProjector(Args&&... args)
+        : Projector(args...)
+        {}
+
+        std::tuple<int, int> project(
+                int origin_x,
+                int origin_y,
+                int w,
+                int h) override {
+            return {
+                origin_x + w - out_margin_x_ + area_bias_x_,
+                origin_y + h / 2
+            } ;
+        }
+    } ;
+
+    struct LowerLeftProjector : public Projector {
+        template <typename... Args>
+        LowerLeftProjector(Args&&... args)
+        : Projector(args...)
+        {}
+
+        std::tuple<int, int> project(
+                int origin_x,
+                int origin_y,
+                int UNUSED(w),
+                int h) override {
+            return {
+                origin_x + out_margin_x_,
+                origin_y + h - out_margin_y_
+            } ;
+        }
+    } ;
+
+    struct LowerMidProjector : public Projector {
+        template <typename... Args>
+        LowerMidProjector(Args&&... args)
+        : Projector(args...)
+        {}
+
+        std::tuple<int, int> project(
+                int origin_x,
+                int origin_y,
+                int w,
+                int h) override {
+            return {
+                origin_x + w / 2 + area_bias_x_,
+                origin_y + h - out_margin_y_
+            } ;
+        }
+    } ;
+
+    struct LowerRightProjector : public Projector {
+        template <typename... Args>
+        LowerRightProjector(Args&&... args)
+        : Projector(args...)
+        {}
+
+        std::tuple<int, int> project(
+                int origin_x,
+                int origin_y,
+                int w,
+                int h) override {
+            return {
+                origin_x + w - out_margin_x_ + area_bias_x_,
+                origin_y + h - out_margin_y_
+            } ;
+        }
+    } ;
+
+    template <typename String, typename... Args>
+    std::unique_ptr<Projector> create_projector(String&& name, Args&&... args) {
+        auto fmt_name = util::A2a(std::forward<String>(name)) ;
+        if(fmt_name == "upperleft") {
+            return std::make_unique<UpperLeftProjector>(args...) ;
+        }
+        if(fmt_name == "uppermid") {
+            return std::make_unique<UpperMidProjector>(args...) ;
+        }
+        if(fmt_name == "upperright") {
+            return std::make_unique<UpperRightProjector>(args...) ;
+        }
+        if(fmt_name == "midleft") {
+            return std::make_unique<MidLeftProjector>(args...) ;
+        }
+        if(fmt_name == "midright") {
+            return std::make_unique<MidRightProjector>(args...) ;
+        }
+        if(fmt_name == "lowerleft") {
+            return std::make_unique<LowerLeftProjector>(args...) ;
+        }
+        if(fmt_name == "lowermid") {
+            return std::make_unique<LowerMidProjector>(args...) ;
+        }
+        if(fmt_name == "lowerright") {
+            return std::make_unique<LowerRightProjector>(args...) ;
+        }
+        return std::make_unique<CenterProjector>(args...) ;
+    }
+}
 
 
 namespace vind
 {
     namespace opt
     {
+        using Projection = std::function<util::Point2D(LONG, LONG)> ;
         struct VCmdLine::Impl {
             util::DisplayTextPainter dtp_{25, FW_MEDIUM, "Consolas"} ;
-            int x_ = 0 ;
-            int y_ = 0 ;
+
+            std::unique_ptr<Projector> projector_{nullptr} ;
             int extra_ = 0 ;
+
+            ProjectionMethod proj_method_ = ProjectionMethod::PRIMARY ;
+
+            std::vector<util::Point2D> coords_{} ;
+            std::size_t fixed_monitor_idx_ = 0 ;
+
             std::chrono::seconds fadeout_time_{} ;
+
+            std::chrono::seconds coords_update_interval_{} ;
+            std::chrono::system_clock::time_point last_coords_update_{} ;
         } ;
 
         Message VCmdLine::msg_ ;
@@ -45,7 +292,7 @@ namespace vind
         VCmdLine& VCmdLine::operator=(VCmdLine&&) = default ;
 
 
-        void VCmdLine::do_enable() const {
+        void VCmdLine::do_enable() {
             auto& settable = core::SetTable::get_instance() ;
 
             pimpl->dtp_.set_font(
@@ -63,44 +310,40 @@ namespace vind
             auto xma = settable.get("cmd_xmargin").get<int>() ;
             auto yma = settable.get("cmd_ymargin").get<int>() ;
 
-            auto rect = util::get_primary_metrics() ;
-
-            auto w = rect.width() ;
-            auto h = rect.height() ;
-
-            constexpr auto midxbuf = 256 ;
-
-            std::unordered_map<std::string, std::pair<int, int>> pos_list {
-                {"UpperLeft",  {xma,                yma}},
-                {"UpperMid",   {w / 2 - midxbuf,    yma}},
-                {"UpperRight", {w - xma - midxbuf,  yma}},
-                {"MidLeft",    {xma,                h / 2}},
-                {"Center",     {w / 2 - midxbuf,    h / 2}},
-                {"MidRight",   {w - xma - midxbuf,  h / 2}},
-                {"LowerLeft",  {xma,                h - yma}},
-                {"LowerMid",   {w / 2 - midxbuf,    h - yma}},
-                {"LowerRight", {w - xma - midxbuf,  h - yma}}
-            } ;
-            try {
-                const auto& p = pos_list.at(
-                        settable.get("cmd_roughpos").get<std::string>()) ;
-                pimpl->x_ = p.first ;
-                pimpl->y_ = p.second ;
+            using namespace std::chrono ;
+            auto mode = util::A2a(settable.get("cmd_monitor").get<std::string>()) ;
+            if(mode == "primary") {
+                pimpl->proj_method_ = ProjectionMethod::PRIMARY ;
+                pimpl->coords_update_interval_ = 30s ;
+                pimpl->fixed_monitor_idx_ = 0 ;
             }
-            catch(const std::out_of_range& e) {
-                const auto& p = pos_list.at("LowerMid") ;
-                pimpl->x_ = p.first ;
-                pimpl->y_ = p.second ;
-                PRINT_ERROR(std::string(e.what()) + "in " + core::SETTINGS().u8string() + \
-                        ", " + settable.get("cmd_roughpos").get<std::string>() + "is invalid syntax.") ;
+            else if(mode == "active") {
+                pimpl->proj_method_ = ProjectionMethod::ACTIVE ;
+                pimpl->coords_update_interval_ = 1s ;
+                pimpl->fixed_monitor_idx_ = 0 ;
             }
+            else if(mode == "all") {
+                pimpl->proj_method_ = ProjectionMethod::ALL ;
+                pimpl->coords_update_interval_ = 30s ;
+                pimpl->fixed_monitor_idx_ = 0 ;
+            }
+            else {
+                pimpl->proj_method_ = ProjectionMethod::FIXED ;
+                pimpl->coords_update_interval_ = 30s ;
+                pimpl->fixed_monitor_idx_ = util::extract_num(mode) ;
+            }
+
+            auto rough_key = settable.get("cmd_roughpos").get<std::string>() ;
+            pimpl->projector_ = create_projector(rough_key, xma, yma) ;
 
             pimpl->extra_ = settable.get("cmd_fontextra").get<int>() ;
             pimpl->fadeout_time_ = std::chrono::seconds(
                     settable.get("cmd_fadeout").get<int>()) ;
+
+            update_drawing_coordinates() ;
         }
 
-        void VCmdLine::do_disable() const {
+        void VCmdLine::do_disable() {
             reset() ;
         }
 
@@ -119,7 +362,67 @@ namespace vind
             }
         }
 
-        void VCmdLine::do_process() const {
+        void VCmdLine::update_drawing_coordinates() {
+            std::vector<util::Box2D> monitors{} ;
+            switch(pimpl->proj_method_) {
+                case ProjectionMethod::PRIMARY: {
+                    monitors.push_back(util::get_primary_metrics()) ;
+                    break ;
+                }
+                case ProjectionMethod::ACTIVE: {
+                    util::Point2D active_pos ;
+                    if(auto hwnd = util::get_foreground_window()) {
+                        auto fg_rect = util::get_window_rect(hwnd) ;
+                        active_pos = fg_rect.center() ;
+                    }
+                    else {
+                        active_pos = util::get_cursor_pos() ;
+                    }
+
+                    util::MonitorInfo minfo ;
+                    util::get_monitor_metrics(active_pos, minfo) ;
+                    monitors.push_back(std::move(minfo.rect)) ;
+                    break ;
+                }
+                case ProjectionMethod::ALL: {
+                    auto minfo_list = util::get_all_monitor_metrics() ;
+                    for(const auto& minfo : minfo_list) {
+                        monitors.push_back(std::move(minfo.rect)) ;
+                    }
+                    break ;
+                }
+                case ProjectionMethod::FIXED: {
+                    auto minfo_list = util::get_all_monitor_metrics() ;
+
+                    if(pimpl->fixed_monitor_idx_ >= minfo_list.size()) {
+                        std::stringstream ss ;
+                        ss << "The specified monitor number " ;
+                        ss << pimpl->fixed_monitor_idx_ << " is out of range." ;
+                        PRINT_ERROR(ss.str()) ;
+                        monitors.push_back(std::move(minfo_list.front().rect)) ;
+                    }
+                    else {
+                        monitors.push_back(std::move(minfo_list[pimpl->fixed_monitor_idx_].rect)) ;
+                    }
+                    break ;
+                }
+            }
+
+            pimpl->coords_.clear() ;
+            for(const auto& rect : monitors) {
+                auto [x, y] = pimpl->projector_->project(
+                        rect.left(), rect.top(),
+                        rect.width(), rect.height()) ;
+
+                pimpl->coords_.emplace_back(x, y) ;
+            }
+
+            pimpl->last_coords_update_ = std::chrono::system_clock::now() ;
+        }
+
+        void VCmdLine::do_process() {
+            using namespace std::chrono ;
+
             if(msg_.empty()) {
                 return ;
             }
@@ -130,7 +433,15 @@ namespace vind
                 }
             }
 
-            pimpl->dtp_.draw(msg_, pimpl->x_, pimpl->y_, pimpl->extra_) ;
+            auto elapsed_time = system_clock::now() - pimpl->last_coords_update_ ;
+            if(elapsed_time > pimpl->coords_update_interval_) {
+                // The coordinates cache is expired.
+                update_drawing_coordinates() ;
+            }
+
+            for(const auto& p : pimpl->coords_) {
+                pimpl->dtp_.draw(msg_, p.x(), p.y(), pimpl->extra_) ;
+            }
         }
     }
 }

--- a/src/opt/vcmdline.cpp
+++ b/src/opt/vcmdline.cpp
@@ -39,14 +39,14 @@ namespace
         const int area_bias_x_ ;
 
         template <typename T1>
-        Projector(T1 out_margin_x, T1 out_margin_y)
+        explicit Projector(T1 out_margin_x, T1 out_margin_y)
         : out_margin_x_(static_cast<int>(out_margin_x)),
           out_margin_y_(static_cast<int>(out_margin_y)),
           area_bias_x_(-256)
         {}
 
         template <typename T1, typename T2>
-        Projector(T1 out_margin_x, T1 out_margin_y, T2 area_bias_x)
+        explicit Projector(T1 out_margin_x, T1 out_margin_y, T2 area_bias_x)
         : out_margin_x_(static_cast<int>(out_margin_x)),
           out_margin_y_(static_cast<int>(out_margin_y)),
           area_bias_x_(static_cast<int>(area_bias_x))
@@ -59,7 +59,7 @@ namespace
 
     struct UpperLeftProjector : public Projector {
         template <typename... Args>
-        UpperLeftProjector(Args&&... args)
+        explicit UpperLeftProjector(Args&&... args)
         : Projector(args...)
         {}
 
@@ -77,7 +77,7 @@ namespace
 
     struct UpperMidProjector : public Projector {
         template <typename... Args>
-        UpperMidProjector(Args&&... args)
+        explicit UpperMidProjector(Args&&... args)
         : Projector(args...)
         {}
 
@@ -95,7 +95,7 @@ namespace
 
     struct UpperRightProjector : public Projector {
         template <typename... Args>
-        UpperRightProjector(Args&&... args)
+        explicit UpperRightProjector(Args&&... args)
         : Projector(args...)
         {}
 
@@ -113,7 +113,7 @@ namespace
 
     struct MidLeftProjector : public Projector {
         template <typename... Args>
-        MidLeftProjector(Args&&... args)
+        explicit MidLeftProjector(Args&&... args)
         : Projector(args...)
         {}
 
@@ -131,7 +131,7 @@ namespace
 
     struct CenterProjector : public Projector {
         template <typename... Args>
-        CenterProjector(Args&&... args)
+        explicit CenterProjector(Args&&... args)
         : Projector(args...)
         {}
 
@@ -149,7 +149,7 @@ namespace
 
     struct MidRightProjector : public Projector {
         template <typename... Args>
-        MidRightProjector(Args&&... args)
+        explicit MidRightProjector(Args&&... args)
         : Projector(args...)
         {}
 
@@ -167,7 +167,7 @@ namespace
 
     struct LowerLeftProjector : public Projector {
         template <typename... Args>
-        LowerLeftProjector(Args&&... args)
+        explicit LowerLeftProjector(Args&&... args)
         : Projector(args...)
         {}
 
@@ -185,7 +185,7 @@ namespace
 
     struct LowerMidProjector : public Projector {
         template <typename... Args>
-        LowerMidProjector(Args&&... args)
+        explicit LowerMidProjector(Args&&... args)
         : Projector(args...)
         {}
 
@@ -203,7 +203,7 @@ namespace
 
     struct LowerRightProjector : public Projector {
         template <typename... Args>
-        LowerRightProjector(Args&&... args)
+        explicit LowerRightProjector(Args&&... args)
         : Projector(args...)
         {}
 

--- a/src/opt/vcmdline.hpp
+++ b/src/opt/vcmdline.hpp
@@ -46,11 +46,9 @@ namespace vind
             struct Impl ;
             std::unique_ptr<Impl> pimpl ;
 
-            void update_drawing() const ;
-
-            void do_enable() const override ;
-            void do_disable() const override ;
-            void do_process() const override ;
+            void do_enable() override ;
+            void do_disable() override ;
+            void do_process() override ;
 
             static Message msg_ ;
 
@@ -93,6 +91,8 @@ namespace vind
 
             // Reset the buffer and pixels
             static void reset() ;
+
+            void update_drawing_coordinates() ;
 
             VCmdLine(const VCmdLine&)            = delete ;
             VCmdLine& operator=(const VCmdLine&) = delete ;

--- a/src/util/display_text_painter.cpp
+++ b/src/util/display_text_painter.cpp
@@ -66,7 +66,7 @@ namespace vind
             pimpl->display_dc = util::create_display_dc() ;
 
             if(enable_double_buffering) {
-                auto box = util::get_conbined_metrics() ;
+                auto box = util::get_combined_metrics() ;
 
                 auto width  = box.width() ;
                 auto height = box.height() ;
@@ -211,7 +211,7 @@ namespace vind
 
         void DisplayTextPainter::refresh() {
             if(pimpl->compatible_dc) {
-                auto box = util::get_conbined_metrics() ;
+                auto box = util::get_combined_metrics() ;
                 if(!BitBlt(pimpl->display_dc.get(), 0, 0,
                            box.width(),
                            box.height(),

--- a/src/util/point2d.hpp
+++ b/src/util/point2d.hpp
@@ -3,6 +3,7 @@
 
 #include <windows.h>
 
+#include <initializer_list>
 #include <utility>
 
 namespace vind
@@ -14,13 +15,18 @@ namespace vind
             POINT pos_ ;
 
         public:
-            explicit Point2D(LONG x=0, LONG y=0)
+            Point2D(LONG x=0, LONG y=0)
             : pos_{x, y}
             {}
 
             template <typename T>
             explicit Point2D(T x, T y)
             : Point2D(static_cast<LONG>(x), static_cast<LONG>(y))
+            {}
+
+            template <typename T>
+            explicit Point2D(std::initializer_list<T>&& pos)
+            : Point2D(*pos.begin(), *(pos.begin() + 1))
             {}
 
             explicit Point2D(const POINT& pos)

--- a/src/util/screen_metrics.cpp
+++ b/src/util/screen_metrics.cpp
@@ -76,7 +76,6 @@ namespace vind
 
                 x += buf.rect.width() ;
                 y_mid = buf.rect.center_y() ;
-
             }
 
             return minfos ;

--- a/src/util/screen_metrics.cpp
+++ b/src/util/screen_metrics.cpp
@@ -5,14 +5,18 @@
 #include <sstream>
 #include <string>
 
+#include "debug.hpp"
 #include "def.hpp"
 #include "rect.hpp"
+
+#define MONITOR_SEARCH_MARGIN (256)
+
 
 namespace vind
 {
     namespace util
     {
-        Box2D get_conbined_metrics() {
+        Box2D get_combined_metrics() {
             WINDOWINFO winfo ;
             winfo.cbSize = sizeof(WINDOWINFO) ;
             if(!GetWindowInfo(GetDesktopWindow(), &winfo)) {
@@ -56,6 +60,26 @@ namespace vind
 
         void get_monitor_metrics(POINT&& pos, MonitorInfo& minfo) {
             get_monitor_metrics(MonitorFromPoint(std::move(pos), MONITOR_DEFAULTTONEAREST), minfo) ;
+        }
+
+        // TODO: we should be implement vertical monitor detection.
+        std::vector<MonitorInfo> get_all_monitor_metrics() {
+            std::vector<MonitorInfo> minfos ;
+            auto entire_box = get_combined_metrics() ;
+
+            MonitorInfo buf ;
+            long x = entire_box.left() + MONITOR_SEARCH_MARGIN ;
+            long y_mid = 1 ;
+            while(x < entire_box.right()) {
+                get_monitor_metrics(Point2D{x, y_mid}, buf) ;
+                minfos.push_back(buf) ;
+
+                x += buf.rect.width() ;
+                y_mid = buf.rect.center_y() ;
+
+            }
+
+            return minfos ;
         }
 
         namespace debug {

--- a/src/util/screen_metrics.hpp
+++ b/src/util/screen_metrics.hpp
@@ -4,6 +4,7 @@
 #include <windows.h>
 
 #include <string>
+#include <vector>
 
 #include "box2d.hpp"
 
@@ -12,7 +13,7 @@ namespace vind
 {
     namespace util
     {
-        Box2D get_conbined_metrics() ;
+        Box2D get_combined_metrics() ;
         Box2D get_primary_metrics() ;
 
         struct MonitorInfo {
@@ -28,6 +29,8 @@ namespace vind
         void get_monitor_metrics(const POINT& pos, MonitorInfo& minfo) ;
 
         void get_monitor_metrics(POINT&& pos, MonitorInfo& minfo) ;
+
+        std::vector<MonitorInfo> get_all_monitor_metrics() ;
 
         namespace debug {
             std::string info(const Box2D& rect) ;


### PR DESCRIPTION
fix #45 
fix #72 

Add the following option to select the monitor on which to draw the command line.

|**name**|**selectable values**|
|:---:|:---:|
|`cmd_monitor`|`primary`, `all`, `active`, `{number}`|

- `primary`
It displays the command line on the primary monitor only, as before.
- `all`
Draws command lines on all monitors.
- `active`
Display command lines on the monitor where the selected window is located.
- `{number}` 
Show the command line on `{number}`th monitor. The `{number}` is a number starting from 0 and assigned from the left monitor. For example, `set cmd_monitor = 1`.