### PR TITLE
Add log path in bug_report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,6 +19,9 @@ To prevent duplicated issue posts, please check the task list at https://github.
 1.
 
 # Environments
+<!--
+Run this in powershell to get the relevant Windows build information :  systeminfo /fo csv | ConvertFrom-Csv | select "OS Name", "OS Version", "System Type" | Format-List 
+-->
 
 |Environments|Delete the example and fill in your information.|
 |:---:|:---|

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,7 +20,7 @@ To prevent duplicated issue posts, please check the task list at https://github.
 
 # Environments
 <!--
-Run this in powershell to get the relevant Windows build information :  systeminfo /fo csv | ConvertFrom-Csv | select "OS Name", "OS Version", "System Type" | Format-List 
+You can find the environment detail in the log files of %USERPROFILE%/.win-vind/log directory. Don't add any personal information here.
 -->
 
 |Environments|Delete the example and fill in your information.|


### PR DESCRIPTION
Add powershell script to gather system info for bug report. It will help people gather the relevant information quickly for a bug report.

Here's what the script returns:

```csv
OS Name     : Microsoft Windows 11 Enterprise
OS Version  : 10.0.22631 N/A Build 22631
System Type : x64-based PC
```

I haven't changed the table format in case you were parsing it somewhere. Feel free to modify the ps script to suit the needs.

